### PR TITLE
test-lxc: sleep a bit before checking for children processes

### DIFF
--- a/test-lxc
+++ b/test-lxc
@@ -190,6 +190,7 @@ distro_apparmor_check ()
     fi
 
     # Check that the whole distro has started
+    sleep 2
     CHILDREN_PS=$(ps --ppid $PROCESS_PID -h)
     assert_match "/sbin/init has no child processes" "/^.\+$/" "$CHILDREN_PS"
 }


### PR DESCRIPTION
The distro_apparmor test fails occasionally with

/sbin/init has no child processes ([] didn't match '/^.\+$/')

Sleeping a bit before checking the child processes seems to help.
Running the test in a loop would fail after 3-5 iterations before
adding the sleep. After the sleep the test ran for 20 iterations
without problems